### PR TITLE
Raise error for bad treeish

### DIFF
--- a/docs/brail/b594c8bdf4f669698fa987a0b3a4b0db5e986ef6
+++ b/docs/brail/b594c8bdf4f669698fa987a0b3a4b0db5e986ef6
@@ -1,0 +1,1 @@
+fix: Raise error for bad treeish


### PR DESCRIPTION
Previously, commands like `brail diff nonexistent123 nonexistent456` would return an empty result-set instead of raising an error.

With this PR, we write an error to stderr and return a non-zero exit code.